### PR TITLE
use HTTPS url for test repo in tests to avoid cloning failures in Travis

### DIFF
--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1643,7 +1643,7 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config = {
             'repo_name': 'testrepository',
-            'url': 'git@github.com:hpcugent',
+            'url': 'https://github.com/hpcugent',
             'tag': 'master',
         }
         target_dir = os.path.join(self.test_prefix, 'target')


### PR DESCRIPTION
@mboisson fixes following test failure on Travis:

```
ERROR: test_get_source_tarball_from_git (test.framework.filetools.FileToolsTest)
Test get_source_tarball_from_git function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/430754932/lib/python2.7/site-packages/easybuild_framework-3.7.0.dev0-py2.7.egg/test/framework/filetools.py", line 1667, in test_get_source_tarball_from_git
    raise err
EasyBuildError: 'cmd "git clone --branch master git@github.com:hpcugent/testrepository.git" exited with exit code 128 and output:\nCloning into \'testrepository\'...\nPermission denied (publickey).\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.\n'
```