### PR TITLE
fix write_file tests after 'overwrite' argument was renamed to 'always_overwrite'

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -790,7 +790,7 @@ class EasyConfig(object):
 
         return self._all_dependencies
 
-    def dump(self, fp, allways_overwrite=True, backup=False):
+    def dump(self, fp, always_overwrite=True, backup=False):
         """
         Dump this easyconfig to file, with the given filename.
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -561,18 +561,18 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(ft.read_file(fp), 'blah')
 
         # blind overwriting can be disabled via 'overwrite'
-        error_pattern = "File exists, not overwriting it without --force: %s" % fp
-        self.assertErrorRegex(EasyBuildError, error_pattern, ft.write_file, fp, 'blah', overwrite=False)
-        self.assertErrorRegex(EasyBuildError, error_pattern, ft.write_file, fp, 'blah', overwrite=False, backup=True)
+        error = "File exists, not overwriting it without --force: %s" % fp
+        self.assertErrorRegex(EasyBuildError, error, ft.write_file, fp, 'blah', always_overwrite=False)
+        self.assertErrorRegex(EasyBuildError, error, ft.write_file, fp, 'blah', always_overwrite=False, backup=True)
 
         # use of --force ensuring that file gets written regardless of whether or not it exists already
         build_options = {'force': True}
         init_config(build_options=build_options)
 
-        ft.write_file(fp, 'overwrittenbyforce', overwrite=False)
+        ft.write_file(fp, 'overwrittenbyforce', always_overwrite=False)
         self.assertEqual(ft.read_file(fp), 'overwrittenbyforce')
 
-        ft.write_file(fp, 'overwrittenbyforcewithbackup', overwrite=False, backup=True)
+        ft.write_file(fp, 'overwrittenbyforcewithbackup', always_overwrite=False, backup=True)
         self.assertEqual(ft.read_file(fp), 'overwrittenbyforcewithbackup')
 
         # also test behaviour of write_file under --dry-run


### PR DESCRIPTION
@mboisson: fix for broken tests in https://github.com/easybuilders/easybuild-framework/pull/2635