### PR TITLE
fix + cleanup support for using version ranges in --filter-deps and add tests

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -604,7 +604,7 @@ class EasyConfig(object):
 
         if range_sep in version_spec:
             # remove range characters to obtain lower/upper version limits
-            version_limits = version_spec.translate(None, '][()').split(range_sep)
+            version_limits = version_spec.translate(None, '][').split(range_sep)
             if len(version_limits) == 2:
                 res['lower'], res['upper'] = version_limits
                 if res['lower'] and res['upper'] and LooseVersion(res['lower']) > LooseVersion('upper'):
@@ -612,8 +612,8 @@ class EasyConfig(object):
             else:
                 raise EasyBuildError("Incorrect version range, expected lower/upper limit: %s", version_spec)
 
-            res['excl_lower'] = version_spec[0] in [']', '(']
-            res['excl_upper'] = version_spec[-1] in ['[', ')']
+            res['excl_lower'] = version_spec[0] == ']'
+            res['excl_upper'] = version_spec[-1] == '['
 
         else:  # strict version spec (not a range)
             res['lower'] = res['upper'] = version_spec

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -624,10 +624,10 @@ class EasyConfig(object):
                     excl_low = dep_version[0] in [']', '(']
                     excl_high = dep_version[-1] in ['[', ')']
                 else:
-                    low, high = dep_version
+                    low = high = dep_version
                     excl_low = False
                     excl_high = False
-                complex_fdeps[k] = {'low':low, 'high':high, 'excl_low':excl_low, 'excl_high':excl_high}
+                complex_fdeps[dep_name] = {'low':low, 'high':high, 'excl_low':excl_low, 'excl_high':excl_high}
 
             filtered_deps = []
             for dep in deps:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1557,7 +1557,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         open(self.logfile, 'w').write('')
 
         # filter deps (including a non-existing dep, i.e. zlib)
-        args.append('--filter-deps=FFTW,ScaLAPACK,zlib')
+        args.extend(['--filter-deps', 'FFTW,ScaLAPACK,zlib'])
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertFalse(re.search('module: FFTW/3.3.3-gompi', outtxt))
         self.assertFalse(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
@@ -1566,7 +1566,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         open(self.logfile, 'w').write('')
 
         # filter specific version of deps
-        args[-1] = '--filter-deps=FFTW=3.2.3,zlib,ScaLAPACK=2.0.2'
+        args[-1] = 'FFTW=3.2.3,zlib,ScaLAPACK=2.0.2'
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertTrue(re.search('module: FFTW/3.3.3-gompi', outtxt))
         self.assertFalse(re.search('module: ScaLAPACK', outtxt))
@@ -1574,7 +1574,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         open(self.logfile, 'w').write('')
 
-        args[-1] = '--filter-deps=FFTW=3.3.3,zlib,ScaLAPACK=2.0.1'
+        args[-1] = 'zlib,FFTW=3.3.3,ScaLAPACK=2.0.1'
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertFalse(re.search('module: FFTW', outtxt))
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
@@ -1583,7 +1583,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         open(self.logfile, 'w').write('')
 
         # filter deps with version range: only filter FFTW 3.x, ScaLAPACK 1.x
-        args[-1] = '--filter-deps=FFTW=[3.0:4.0[,zlib,ScaLAPACK=]1.0:2.0['
+        args[-1] = 'zlib,ScaLAPACK=]1.0:2.0[,FFTW=[3.0:4.0['
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertFalse(re.search('module: FFTW', outtxt))
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
@@ -1591,8 +1591,23 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         open(self.logfile, 'w').write('')
 
+        # also test open ended ranges
+        args[-1] = 'zlib,ScaLAPACK=[1.0:,FFTW=:4.0['
+        outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
+        self.assertFalse(re.search('module: FFTW', outtxt))
+        self.assertFalse(re.search('module: ScaLAPACK', outtxt))
+        self.assertFalse(re.search('module: zlib', outtxt))
+
+        open(self.logfile, 'w').write('')
+
+        args[-1] = 'zlib,ScaLAPACK=[2.1:,FFTW=:3.0['
+        outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
+        self.assertTrue(re.search('module: FFTW/3.3.3-gompi', outtxt))
+        self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
+        self.assertFalse(re.search('module: zlib', outtxt))
+
         # test corner cases where version to filter in equal to low/high range limit
-        args[-1] = '--filter-deps=FFTW=[3.3.3:4.0],zlib,ScaLAPACK=[1.0:2.0.2]'
+        args[-1] = 'FFTW=[3.3.3:4.0],zlib,ScaLAPACK=[1.0:2.0.2]'
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertFalse(re.search('module: FFTW', outtxt))
         self.assertFalse(re.search('module: ScaLAPACK', outtxt))
@@ -1601,7 +1616,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         open(self.logfile, 'w').write('')
 
         # FFTW & ScaLAPACK versions are not included in range, so no filtering
-        args[-1] = '--filter-deps=FFTW=]3.3.3:4.0],zlib,ScaLAPACK=[1.0:2.0.2['
+        args[-1] = 'FFTW=]3.3.3:4.0],zlib,ScaLAPACK=[1.0:2.0.2['
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertTrue(re.search('module: FFTW/3.3.3-gompi', outtxt))
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
@@ -1610,14 +1625,14 @@ class CommandLineOptionsTest(EnhancedTestCase):
         open(self.logfile, 'w').write('')
 
         # also test mix of ranges & specific versions
-        args[-1] = '--filter-deps=FFTW=3.3.3,zlib,ScaLAPACK=[1.0:2.0.2['
+        args[-1] = 'FFTW=3.3.3,zlib,ScaLAPACK=[1.0:2.0.2['
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertFalse(re.search('module: FFTW', outtxt))
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
         open(self.logfile, 'w').write('')
-        args[-1] = '--filter-deps=FFTW=]3.3.3:4.0],zlib,ScaLAPACK=2.0.2'
+        args[-1] = 'FFTW=]3.3.3:4.0],zlib,ScaLAPACK=2.0.2'
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertTrue(re.search('module: FFTW/3.3.3-gompi', outtxt))
         self.assertFalse(re.search('module: ScaLAPACK', outtxt))


### PR DESCRIPTION
@mboisson Some additional work on top of https://github.com/easybuilders/easybuild-framework/pull/2357.

While adding tests I quickly noticed that https://github.com/easybuilders/easybuild-framework/pull/2357 in its current form can never have worked, due to:

* `complex_fdeps[k]` should be `complex_fdeps[dep_name]`, otherwise you quickly run into an undefined variable

* `low, high = dep_version` should be `low = high = dep_version` or `low, high = dep_version, dep_version`

While I was at it, I also broke up the implementation a bit into separate methods, and cleaned things up a bit.