### PR TITLE
bug fix, code cleanup + dedicated test for installation lock

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3060,7 +3060,13 @@ class EasyBlock(object):
 
             # create lock to avoid that another installation running in parallel messes things up;
             # we use a directory as a lock, since that's atomically created
-            mkdir(lock_path, parents=True)
+            try:
+                mkdir(lock_path, parents=True)
+            except EasyBuildError as err:
+                # clean up the error message a bit, get rid of the "Failed to create directory" part + quotes
+                stripped_err = str(err).split(':', 1)[1].strip().replace("'", '').replace('"', '')
+                raise EasyBuildError("Failed to create lock %s: %s", lock_path, stripped_err)
+
             self.log.info("Lock created: %s", lock_path)
 
         try:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3044,10 +3044,12 @@ class EasyBlock(object):
 
         # if lock already exists, either abort or wait until it disappears
         if os.path.exists(lock_fp):
-            if build_option('wait_on_lock'):
+            wait_on_lock = build_option('wait_on_lock')
+            if wait_on_lock:
                 while os.path.exists(lock_fp):
-                    print_msg("lock file in %s exists, waiting 60 seconds..." % locks_dir, silent=self.silent)
-                    time.sleep(60)
+                    print_msg("lock file %s exists, waiting %d seconds..." % (lock_fp, wait_on_lock),
+                              silent=self.silent)
+                    time.sleep(wait_on_lock)
             else:
                 raise EasyBuildError("Lock file %s already exists, aborting!", lock_fp)
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3039,7 +3039,7 @@ class EasyBlock(object):
         print_msg("building and installing %s..." % self.full_mod_name, log=self.log, silent=self.silent)
         trace_msg("installation prefix: %s" % self.installdir)
 
-        locks_dir = build_option('lockpath') or os.path.join(install_path('software'), '.locks')
+        locks_dir = build_option('locks_dir') or os.path.join(install_path('software'), '.locks')
         lock_fp = os.path.join(locks_dir, '%s.lock' % self.installdir.replace('/', '_'))
 
         # if lock already exists, either abort or wait until it disappears

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3052,8 +3052,8 @@ class EasyBlock(object):
                 raise EasyBuildError("Lock file %s already exists, aborting!", lock_fp)
 
         # create lock file to avoid that another installation running in parallel messes things up
-        print_msg("creating lock file %s" % lock_fp, silent=self.silent)
         write_file(lock_fp, 'lock for %s' % self.installdir)
+        self.log.info("Lock file created: %s", lock_fp)
 
         try:
             for (step_name, descr, step_methods, skippable) in steps:
@@ -3070,8 +3070,8 @@ class EasyBlock(object):
         except StopException:
             pass
         finally:
-            print_msg("removing lock file %s" % lock_fp, silent=self.silent)
             remove_file(lock_fp)
+            self.log.info("Lock file removed: %s", lock_fp)
 
         # return True for successfull build (or stopped build)
         return True

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -185,7 +185,7 @@ BUILD_OPTIONS_CMDLINE = {
         'job_output_dir',
         'job_polling_interval',
         'job_target_resource',
-        'lockpath',
+        'locks_dir',
         'modules_footer',
         'modules_header',
         'mpi_cmd_template',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -226,6 +226,7 @@ BUILD_OPTIONS_CMDLINE = {
         'group_writable_installdir',
         'hidden',
         'ignore_checksums',
+        'ignore_locks',
         'install_latest_eb_release',
         'lib64_fallback_sanity_check',
         'logtostdout',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -435,8 +435,8 @@ class EasyBuildOptions(GeneralOption):
                                      None, 'store_true', False),
             'verify-easyconfig-filenames': ("Verify whether filename of specified easyconfigs matches with contents",
                                             None, 'store_true', False),
-            'wait-on-lock': ("Wait until lock file is removed when a lock if found",
-                             None, 'store_true', False),
+            'wait-on-lock': ("Wait interval (in seconds) to use when waiting for existing lock to be removed "
+                "(0: implies no waiting, but exiting with an error)", int, 'store', 0),
             'zip-logs': ("Zip logs that are copied to install directory, using specified command",
                          None, 'store_or_None', 'gzip'),
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -257,7 +257,8 @@ class EasyBuildOptions(GeneralOption):
                       "and skipping check for OS dependencies", None, 'store_true', False, 'f'),
             'job': ("Submit the build as a job", None, 'store_true', False),
             'logtostdout': ("Redirect main log to stdout", None, 'store_true', False, 'l'),
-            'lockpath': ("Specifies which path should be used to store lock files", None, 'store_or_None', None),
+            'locks-dir': ("Directory to store lock files (should be on a shared filesystem); "
+                "None implies .locks subdirectory of software installation directory", None, 'store_or_None', None),
             'missing-modules': ("Print list of missing modules for dependencies of specified easyconfigs",
                                 None, 'store_true', False, 'M'),
             'only-blocks': ("Only build listed blocks", 'strlist', 'extend', None, 'b', {'metavar': 'BLOCKS'}),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -255,6 +255,8 @@ class EasyBuildOptions(GeneralOption):
             'extended-dry-run-ignore-errors': ("Ignore errors that occur during dry run", None, 'store_true', True),
             'force': ("Force to rebuild software even if it's already installed (i.e. if it can be found as module), "
                       "and skipping check for OS dependencies", None, 'store_true', False, 'f'),
+            'ignore-locks': ("Ignore locks that prevent two identical installations running in parallel",
+                             None, 'store_true', False),
             'job': ("Submit the build as a job", None, 'store_true', False),
             'logtostdout': ("Redirect main log to stdout", None, 'store_true', False, 'l'),
             'locks-dir': ("Directory to store lock files (should be on a shared filesystem); "

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -34,10 +34,12 @@ import grp
 import os
 import re
 import shutil
+import signal
 import stat
 import sys
 import tempfile
 from distutils.version import LooseVersion
+from functools import wraps
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from test.framework.package import mock_fpm
 from unittest import TextTestRunner
@@ -2515,6 +2517,84 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
 
         self.assertFalse(os.path.exists(toy_installdir))
+
+    def test_toy_build_lock(self):
+        """Test toy installation when a lock is already in place."""
+
+        locks_dir = os.path.join(self.test_installpath, 'software', '.locks')
+        toy_installdir = os.path.join(self.test_installpath, 'software', 'toy', '0.0')
+        toy_lock_fn = toy_installdir.replace(os.path.sep, '_') + '.lock'
+
+        write_file(os.path.join(locks_dir, toy_lock_fn), '')
+
+        error_pattern = "Lock file .*_software_toy_0.0.lock already exists, aborting!"
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.test_toy_build, raise_error=True, verbose=False)
+
+        locks_dir = os.path.join(self.test_prefix, 'locks')
+
+        # no lock in place, so installation proceeds as normal
+        extra_args = ['--locks-dir=%s' % locks_dir]
+        self.test_toy_build(extra_args=extra_args, verify=True, raise_error=True)
+
+        # put lock in place in custom locks dir, try again
+        toy_lock_fp = os.path.join(locks_dir, toy_lock_fn)
+        write_file(toy_lock_fp, '')
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.test_toy_build,
+                              extra_args=extra_args, raise_error=True, verbose=False)
+
+        # define a context manager that remove a lock after a while, so we can check the use of --wait-for-lock
+        class remove_lock_after:
+            def __init__(self, seconds, lock_fp):
+                self.seconds = seconds
+                self.lock_fp = lock_fp
+
+            def remove_lock(self, *args):
+                remove_file(self.lock_fp)
+
+            def __enter__(self):
+                signal.signal(signal.SIGALRM, self.remove_lock)
+                signal.alarm(self.seconds)
+
+            def __exit__(self, type, value, traceback):
+                pass
+
+        # wait for lock to be removed, with 1 second interval of checking
+        extra_args.append('--wait-on-lock=1')
+
+        wait_regex = re.compile("^== lock file .*_software_toy_0.0.lock exists, waiting 1 seconds", re.M)
+        ok_regex = re.compile("^== COMPLETED: Installation ended successfully", re.M)
+
+        self.assertTrue(os.path.exists(toy_lock_fp))
+
+        # use context manager to remove lock file after 3 seconds
+        with remove_lock_after(3, toy_lock_fp):
+            self.mock_stderr(True)
+            self.mock_stdout(True)
+            self.test_toy_build(extra_args=extra_args, verify=False, raise_error=True, testing=False)
+            stderr, stdout = self.get_stderr(), self.get_stdout()
+            self.mock_stderr(False)
+            self.mock_stdout(False)
+
+            self.assertEqual(stderr, '')
+
+            wait_matches = wait_regex.findall(stdout)
+            # we can't rely on an exact number of 'waiting' messages, so let's go with a range...
+            self.assertTrue(len(wait_matches) in range(2, 5))
+
+            self.assertTrue(ok_regex.search(stdout), "Pattern '%s' found in: %s" % (ok_regex.pattern, stdout))
+
+        # when there is no lock in place, --wait-on-lock has no impact
+        self.assertFalse(os.path.exists(toy_lock_fp))
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        self.test_toy_build(extra_args=extra_args, verify=False, raise_error=True, testing=False)
+        stderr, stdout = self.get_stderr(), self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        self.assertEqual(stderr, '')
+        self.assertTrue(ok_regex.search(stdout), "Pattern '%s' found in: %s" % (ok_regex.pattern, stdout))
+        self.assertFalse(wait_regex.search(stdout), "Pattern '%s' not found in: %s" % (wait_regex.pattern, stdout))
 
 
 def suite():

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1417,7 +1417,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertTrue(os.path.exists(os.path.join(self.test_installpath, 'software', 'toy', '0.0-deps', 'bin')))
         modtxt = read_file(toy_mod)
         self.assertTrue(re.search("set root %s" % prefix, modtxt))
-        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 1)
+        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 2)
         self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software', 'toy'))), 1)
 
         # install (only) additional module under a hierarchical MNS
@@ -1432,7 +1432,7 @@ class ToyBuildTest(EnhancedTestCase):
         # existing install is reused
         modtxt2 = read_file(toy_core_mod)
         self.assertTrue(re.search("set root %s" % prefix, modtxt2))
-        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 2)
+        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 3)
         self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software', 'toy'))), 1)
 
         # make sure load statements for dependencies are included
@@ -2059,7 +2059,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertTrue(os.path.exists(os.path.join(modules_path, 'yot', yot_name)))
 
         # only subdirectories for software should be created
-        self.assertEqual(os.listdir(software_path), ['toy'])
+        self.assertEqual(os.listdir(software_path), ['toy', '.locks'])
         self.assertEqual(sorted(os.listdir(os.path.join(software_path, 'toy'))), ['0.0-one', '0.0-two'])
 
         # only subdirectories for modules with alternative names should be created

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1443,7 +1443,7 @@ class ToyBuildTest(EnhancedTestCase):
         os.remove(toy_core_mod)
 
         # test installing (only) additional module in Lua syntax (if Lmod is available)
-        lmod_abspath = which('lmod')
+        lmod_abspath = os.environ.get('LMOD_CMD') or which('lmod')
         if lmod_abspath is not None:
             args = common_args[:-1] + [
                 '--allow-modules-tool-mismatch',
@@ -1457,7 +1457,7 @@ class ToyBuildTest(EnhancedTestCase):
             # existing install is reused
             modtxt3 = read_file(toy_mod + '.lua')
             self.assertTrue(re.search('local root = "%s"' % prefix, modtxt3))
-            self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 2)
+            self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 3)
             self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software', 'toy'))), 1)
 
             # make sure load statements for dependencies are included

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1417,7 +1417,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertTrue(os.path.exists(os.path.join(self.test_installpath, 'software', 'toy', '0.0-deps', 'bin')))
         modtxt = read_file(toy_mod)
         self.assertTrue(re.search("set root %s" % prefix, modtxt))
-        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 2)
+        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 1)
         self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software', 'toy'))), 1)
 
         # install (only) additional module under a hierarchical MNS
@@ -1432,7 +1432,7 @@ class ToyBuildTest(EnhancedTestCase):
         # existing install is reused
         modtxt2 = read_file(toy_core_mod)
         self.assertTrue(re.search("set root %s" % prefix, modtxt2))
-        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 3)
+        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 2)
         self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software', 'toy'))), 1)
 
         # make sure load statements for dependencies are included
@@ -1457,7 +1457,7 @@ class ToyBuildTest(EnhancedTestCase):
             # existing install is reused
             modtxt3 = read_file(toy_mod + '.lua')
             self.assertTrue(re.search('local root = "%s"' % prefix, modtxt3))
-            self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 3)
+            self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 2)
             self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software', 'toy'))), 1)
 
             # make sure load statements for dependencies are included
@@ -2059,7 +2059,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertTrue(os.path.exists(os.path.join(modules_path, 'yot', yot_name)))
 
         # only subdirectories for software should be created
-        self.assertEqual(sorted(os.listdir(software_path)), sorted(['.locks', 'toy']))
+        self.assertEqual(os.listdir(software_path), ['toy'])
         self.assertEqual(sorted(os.listdir(os.path.join(software_path, 'toy'))), ['0.0-one', '0.0-two'])
 
         # only subdirectories for modules with alternative names should be created
@@ -2541,6 +2541,9 @@ class ToyBuildTest(EnhancedTestCase):
         write_file(toy_lock_fp, '')
         self.assertErrorRegex(EasyBuildError, error_pattern, self.test_toy_build,
                               extra_args=extra_args, raise_error=True, verbose=False)
+
+        # also test use of --ignore-locks
+        self.test_toy_build(extra_args=extra_args + ['--ignore-locks'], verify=True, raise_error=True)
 
         # define a context manager that remove a lock after a while, so we can check the use of --wait-for-lock
         class remove_lock_after:


### PR DESCRIPTION
@mboisson for https://github.com/easybuilders/easybuild-framework/pull/3009

High-level overview of changes:

* make sure installation actually proceeds after lock is removed when `--wait-on-lock` is used
* don't print messages when lock is acquired/removed (should be done in background)
* make wait interval configurable by letting `--wait-on-lock` accept an argument
* renamed `--lockpath` to `--locks-dir`
* added `--ignore-locks` option
* add dedicated test to check lock feature & related configuration options
* code cleanup